### PR TITLE
compatibility with linux ROMS

### DIFF
--- a/guide/English/1-partition-en.md
+++ b/guide/English/1-partition-en.md
@@ -63,39 +63,40 @@ rm 32
 <details>
 <summary><b><strong>For 128GB Models</strong></b></summary>
 
-- Create the ESP partition (stores Windows bootloader data and EFI files)
+
+
+- Create Android's data partition
 ```sh
-mkpart esp fat32 11.8GB 12.2GB
+mkpart userdata ext4 11.8GB 68.6GB
 ```
 
 - Create the main partition where Windows will be installed to
 ```sh
-mkpart win ntfs 12.2GB 70.2GB
+mkpart win ntfs 68.6GB 126.6GB
 ```
 
-- Create Android's data partition
+- Create the ESP partition (stores Windows bootloader data and EFI files)
 ```sh
-mkpart userdata ext4 70.2GB 127GB
+mkpart esp fat32 126.6GB 127GB 
 ```
   </summary>
 </details>
 
 <details>
 <summary><b><strong>For 256GB Models</strong></b></summary>
-
-- Create the ESP partition (stores Windows bootloader data and EFI files)
+- Create Android's data partition
 ```sh
-mkpart esp fat32 11.8GB 12.2GB
+mkpart userdata ext4 11.8GB 134.6GB
 ```
 
 - Create the main partition where Windows will be installed to
 ```sh
-mkpart win ntfs 12.2GB 132.2GB
+mkpart win ntfs 134.6GB 254.6GB
 ```
 
-- Create Android's data partition
+- Create the ESP partition (stores Windows bootloader data and EFI files)
 ```sh
-mkpart userdata ext4 132.2GB 255GB
+mkpart esp fat32 254.6GB 255GB
 ```
   </summary>
 </details>

--- a/guide/Español/1-particiones-es.md
+++ b/guide/Español/1-particiones-es.md
@@ -55,38 +55,37 @@ rm 32
 > Si recibes cualquier advertencia que te diga ignorar o cancelar, solo escribe i y dale a enter enter
 
 #### Para los modelos de 128Gb:
-
-- Crea la partición ESP (Aqui estará el bootloader de Windows y los archivos EFI)
+- Creamos la partición de datos de Android
 ```sh
-mkpart esp fat32 11.8GB 12.2GB
+mkpart userdata ext4 11.8GB 68.6GB
 ```
 
 - Creamos la partición principal donde instalaremos Windows
 ```sh
-mkpart win ntfs 12.2GB 70.2GB
+mkpart win ntfs 68.6GB 126.6GB
 ```
 
-- Creamos la partición de datos de Android
+- Crea la partición ESP (Aqui estará el bootloader de Windows y los archivos EFI)
 ```sh
-mkpart userdata ext4 70.2GB 127GB
+mkpart esp fat32 126.6GB 127GB 
 ```
 
 
 #### Para modelos de 256Gb:
 
-- Crea la partición ESP (Aqui estará el bootloader de Windows y los archivos EFI)
+- Creamos la partición de datos de Android
 ```sh
-mkpart esp fat32 11.8GB 12.2GB
+mkpart userdata ext4 11.8GB 134.6GB
 ```
 
 - Creamos la partición principal donde instalaremos Windows
 ```sh
-mkpart win ntfs 12.2GB 132.2GB
+mkpart win ntfs 134.6GB 254.6GB
 ```
 
-- Creamos la partición de datos de Android
+- Crea la partición ESP (Aqui estará el bootloader de Windows y los archivos EFI)
 ```sh
-mkpart userdata ext4 132.2GB 255GB
+mkpart esp fat32 254.6GB 255GB
 ```
 
 

--- a/guide/Lithuanian/1-partition-lt.md
+++ b/guide/Lithuanian/1-partition-lt.md
@@ -46,37 +46,37 @@ rm 32
 
 #### Skirta 128Gb modeliams:
 
-- Sukurkite ESP particiją (čia bus laikoma Windows paleidimo instrukcijos ir EFI failai)
+- Sukurkite Android duomenų particiją
 ```sh
-mkpart esp fat32 11.8GB 12.2GB
+mkpart userdata ext4 11.8GB 68.6GB
 ```
 
 - Sukurkite pagrindinę particiją, kur bus įrašyti Windows
 ```sh
-mkpart win ntfs 12.2GB 70.2GB
+mkpart win ntfs 68.6GB 126.6GB
 ```
 
-- Sukurkite Android duomenų particiją
+- Sukurkite ESP particiją (čia bus laikoma Windows paleidimo instrukcijos ir EFI failai)
 ```sh
-mkpart userdata ext4 70.2GB 127GB
+mkpart esp fat32 126.6GB 127GB
 ```
 
 
 #### Skirta 256Gb modeliams:
 
-- Sukurkite ESP particiją (čia bus laikoma Windows paleidimo instrukcijos ir EFI failai)
+- Sukurkite Android duomenų particiją
 ```sh
-mkpart esp fat32 11.8GB 12.2GB
+mkpart userdata ext4 11.8GB 134.6GB
 ```
 
 -  Sukurkite pagrindinę particiją, kur bus įrašyti Windows
 ```sh
-mkpart win ntfs 12.2GB 132.2GB
+mkpart win ntfs 134.6GB 254.6GB
 ```
 
-- Sukurkite Android duomenų particiją
+- Sukurkite ESP particiją (čia bus laikoma Windows paleidimo instrukcijos ir EFI failai)
 ```sh
-mkpart userdata ext4 132.2GB 255GB
+mkpart esp fat32 254.6GB 255GB
 ```
 
 

--- a/guide/Russian/1-partition-ru.md
+++ b/guide/Russian/1-partition-ru.md
@@ -54,39 +54,37 @@ rm 32
 
 <details>
 <summary><strong>Для моделей 6/128</strong></summary>
-
-- Создайте ESP раздел (будет содержать загрузчик Windows)
+- Создайте раздел `userdata` для использования Android вместе с Windows
 ```sh
-mkpart esp fat32 11.8GB 12.2GB
+mkpart userdata ext4 11.8GB 68.6GB
 ```
 
 - Создайте раздел, в который будет установлена Windows
 ```sh
-mkpart win ntfs 12.2GB 70.2GB
+mkpart win ntfs 68.6GB 126.6GB
 ```
 
-- Создайте раздел `userdata` для использования Android вместе с Windows
+- Создайте ESP раздел (будет содержать загрузчик Windows)
 ```sh
-mkpart userdata ext4 70.2GB 127GB
+mkpart esp fat32 126.6GB 127GB
 ```
 </details>
 
 <details>
 <summary><strong>Для моделей 8/256</strong></summary>
-
-- Создайте ESP раздел (будет содержать загрузчик Windows)
+- Создайте раздел `userdata` для использования Android вместе с Windows
 ```sh
-mkpart esp fat32 11.8GB 12.2GB
+mkpart userdata ext4 11.8GB 134.6GB
 ```
 
 - Создайте раздел на который будет установлена Windows
 ```sh
-mkpart win ntfs 12.2GB 132.2GB
+mkpart win ntfs 134.6GB 254.6GB
 ```
 
-- Создайте раздел `userdata` для использования Android вместе с Windows
+- Создайте ESP раздел (будет содержать загрузчик Windows)
 ```sh
-mkpart userdata ext4 132.2GB 255GB
+mkpart esp fat32 254.6GB 255GB
 ```
 </details>
 

--- a/guide/Ukrainian/1-partition-uk.md
+++ b/guide/Ukrainian/1-partition-uk.md
@@ -55,33 +55,33 @@ rm 32
 <details> 
 <summary><strong>Для моделей 6/128</strong></summary>
 
-- Створіть ESP розділ (буде містити завантажувач Windows)
+- Створіть розділ `userdata` для використання Android поряд з Windows
 ```sh
-mkpart esp fat32 11.8GB 12.2GB
+mkpart userdata ext4 11.8GB 68.6GB
 ```
 - Створіть розділ, до якого буде встановлена Windows
 ```sh
-mkpart win ntfs 12.2GB 70.2GB
+mkpart win ntfs 68.6GB 126.6GB
 ```
-- Створіть розділ `userdata` для використання Android поряд з Windows
+- Створіть ESP розділ (буде містити завантажувач Windows)
 ```sh
-mkpart userdata ext4 70.2GB 127GB
+mkpart esp fat32 126.6GB 127GB
 ```
 </details>
 <details> 
 <summary><strong>Для моделей 8/256</strong></summary>
 
-- Створіть ESP розділ (буде містити завантажувач Windows)
+- Створіть розділ `userdata` для використання Android поряд з Windows
 ```sh
-mkpart esp fat32 11.8GB 12.2GB
+mkpart userdata ext4 11.8GB 134.6GB
 ```
 - Створіть розділ, до якого буде встановлена Windows
 ```sh
-mkpart win ntfs 12.2GB 132.2GB
+mkpart win ntfs 134.6GB 254.6GB
 ```
-- Створіть розділ `userdata` для використання Android поряд з Windows
+- Створіть ESP розділ (буде містити завантажувач Windows)
 ```sh
-mkpart userdata ext4 132.2GB 255GB
+mkpart esp fat32 254.6GB 255GB
 ```
 </details> 
 


### PR DESCRIPTION
Example of that is sailfish os requires the userdata partition to be exactly in the 32 position
this edit will make the userdata in 32.


calculated and verified,
you are free to take a look at it, and comment if there's a typo